### PR TITLE
Mw Filtering out pending orders from merchant order fulfillment page in dashboard

### DIFF
--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -138,7 +138,7 @@ class OrderItemsController < ApplicationController
       end
 
       if unshipped_order == 0
-        current_order.update(status: "complete")
+        current_order.update(status: "completed")
       elsif unshipped_order <= order_count
         current_order.update(status: "paid")
       end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -16,19 +16,30 @@ class Merchant < ApplicationRecord
 
   def self.find_order_items(merchant, status)
     orders = []
+
     if merchant.class == Merchant
       products = merchant.products
       products.each do |product|
         order_items = Orderitem.find_order_items_by_product(product)
-        order_items.each do |order_item|
-          if status == "all"
-            orders << order_item
-          elsif order = find_order_by_status(order_item, status)
-            orders << order_item
+        if status == "all"
+          statuses = ["completed", "paid", "cancelled"]
+          statuses.each do |s|
+            order_items.each do |order_item|
+              if order = find_order_by_status(order_item, s)
+                orders << order_item
+              end
+            end
+          end
+        else
+          order_items.each do |order_item|
+            if order = find_order_by_status(order_item, status)
+              orders << order_item
+            end
           end
         end
       end
     end
+
     return orders.sort!
   end
 


### PR DESCRIPTION
We discussed again what it means for an order to be pending.
We agreed that a pending order is an order that hasn’t been checkout (paid). Therefore such order is a cart and should not be displayed in the merchants order fulfillment page in dashboard.


